### PR TITLE
Update about.md

### DIFF
--- a/commandline/WSL/about.md
+++ b/commandline/WSL/about.md
@@ -30,11 +30,11 @@ This video from Build 2016 gives you more information and a demo of Ubuntu on Wi
 <iframe src="https://channel9.msdn.com/Events/Build/2016/P488/player" width="800" height="450"  allowFullScreen="true" frameBorder="0" scrolling="no"></iframe>
 
 ## Get started
-[Installation guide](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide)
-[Command reference](https://msdn.microsoft.com/en-us/commandline/wsl/reference)
-[User support](https://msdn.microsoft.com/en-us/commandline/wsl/user_support)
-[Frequently asked questions](https://msdn.microsoft.com/en-us/commandline/wsl/faq)
-[Release notes](https://msdn.microsoft.com/en-us/commandline/wsl/release_notes)
+* [Installation guide](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide)
+* [Command reference](https://msdn.microsoft.com/en-us/commandline/wsl/reference)
+* [User support](https://msdn.microsoft.com/en-us/commandline/wsl/user_support)
+* [Frequently asked questions](https://msdn.microsoft.com/en-us/commandline/wsl/faq)
+* [Release notes](https://msdn.microsoft.com/en-us/commandline/wsl/release_notes)
 
 ## Announcements
 


### PR DESCRIPTION
Get Started links didn't have spaces between them in [msdn](https://msdn.microsoft.com/en-us/commandline/wsl/about)
