### PR TITLE
Removed the incomplete words from the first bullet point

### DIFF
--- a/commandline/WSL/about.md
+++ b/commandline/WSL/about.md
@@ -26,7 +26,7 @@ an entire Linux virtual machine!
 
 Bash/WSL allows you to:
 
-1. Run common command-line utilities such as `grep`, `sed`, `awk`, etc. delivered by an
+1. Run common command-line utilities such as `grep`, `sed`, `awk`, etc.
 1. Use the Linux-compatible filesystem & heirarchy and access fixed Windows storage 
 mounted under `/mnt/...`
 1. Run Bash shell scripts and Linux command-line apps. including


### PR DESCRIPTION
The phrase "delivered by an" should not be there under the first bullet point under what "Bash/WSL allows" you to do.